### PR TITLE
#139551641 Add tests for front application

### DIFF
--- a/hc/front/tests/test_add_channel.py
+++ b/hc/front/tests/test_add_channel.py
@@ -37,23 +37,35 @@ class AddChannelTestCase(BaseTestCase):
             r = self.client.get(url)
             self.assertContains(r, "Integration Settings", status_code=200)
 
-    def test_team_access_with_invite(self):
+    def test_team_access_using_invite(self):
         ''' Test that the team access works '''
         # Log Alice in
         self.client.login(username="alice@example.org", password="password")
 
         # Create POST data to send to profile view function
-        post_data = {"invite_team_member": "1", "email": "bob@example.org"}
-        r = self.client.post("/accounts/profile/", post_data)
+        form = {"invite_team_member": "1", "email": "bob@example.org"}
+        r = self.client.post("/accounts/profile/", form)
         assert r.status_code == 200
 
-    def test_team_access_with_set_team_name(self):
+    def test_team_access_using_set_team_name(self):
         ''' Test that the team access works with set team name '''
         # Log in as Alice
         self.client.login(username="alice@example.org", password="password")
-        post_data = {"set_team_name": "1", "team_name": "Alphas"}
-        r = self.client.post("/accounts/profile/", post_data)
+        form = {"set_team_name": "1", "team_name": "Alphas"}
+        r = self.client.post("/accounts/profile/", form)
         assert r.status_code == 200
 
+    def test_bad_kinds_dont_work(self):
+        ''' Test that bad kinds don't work '''
+        # Log in as Alice
+        self.client.login(username="alice@example.org", password="password")
 
-    ### Test that bad kinds don't work
+        # A random string to use as kind
+        kind = "raqwertyuiop654321"
+
+        url = "/integrations/add/"
+        form = {"kind": kind, "value": "alice@example.org"}
+        r = self.client.post(url, form)
+        assert r.status_code == 400
+
+

--- a/hc/front/tests/test_add_channel.py
+++ b/hc/front/tests/test_add_channel.py
@@ -47,6 +47,13 @@ class AddChannelTestCase(BaseTestCase):
         r = self.client.post("/accounts/profile/", post_data)
         assert r.status_code == 200
 
-    
-    
+    def test_team_access_with_set_team_name(self):
+        ''' Test that the team access works with set team name '''
+        # Log in as Alice
+        self.client.login(username="alice@example.org", password="password")
+        post_data = {"set_team_name": "1", "team_name": "Alphas"}
+        r = self.client.post("/accounts/profile/", post_data)
+        assert r.status_code == 200
+
+
     ### Test that bad kinds don't work

--- a/hc/front/tests/test_add_channel.py
+++ b/hc/front/tests/test_add_channel.py
@@ -37,5 +37,16 @@ class AddChannelTestCase(BaseTestCase):
             r = self.client.get(url)
             self.assertContains(r, "Integration Settings", status_code=200)
 
-    ### Test that the team access works
+    def test_team_access_with_invite(self):
+        ''' Test that the team access works '''
+        # Log Alice in
+        self.client.login(username="alice@example.org", password="password")
+
+        # Create POST data to send to profile view function
+        post_data = {"invite_team_member": "1", "email": "bob@example.org"}
+        r = self.client.post("/accounts/profile/", post_data)
+        assert r.status_code == 200
+
+    
+    
     ### Test that bad kinds don't work

--- a/hc/front/tests/test_add_pushbover.py
+++ b/hc/front/tests/test_add_pushbover.py
@@ -37,4 +37,17 @@ class AddPushoverTestCase(BaseTestCase):
         r = self.client.get("/integrations/add_pushover/?%s" % params)
         assert r.status_code == 403
 
-    ### Test that pushover validates priority
+    def test_it_validates_priority(self):
+        ''' Test that pushover validates priority '''
+        self.client.login(username="alice@example.org", password="password")
+
+        nonce = "randnonce"
+        priority = 99
+        session = self.client.session
+        session["po_nonce"] = nonce
+        session.save()
+
+        params = "pushover_user_key=a&nonce=%s&prio=%d" % (nonce, priority)
+        r = self.client.get("/integrations/add_pushover/?%s" % params)
+        assert r.status_code == 400
+


### PR DESCRIPTION
### What does this PR do?
Add front tests.

### The following tests were added:-
`test_team_access_using_invite` 
- `hc/front/tests/test_add_channel.py`
- Test that the team access works

`test_team_access_using_set_team_name`
- `hc/front/tests/test_add_channel.py`
- Test that the team access works

`test_bad_kinds_dont_work`
- `hc/front/tests/test_add_channel.py`
- Test that bad kinds don't work

`test_it_validates_priority` 
- `hc/front/tests/test_add_pushover.py`
- Test that pushover validates priority

### How should this be manually tested?
At the root of the project folder, execute the following command:
`./manage.py test hc/front`

### What are the relevant pivotal tracker stories?
The Front tests need fixing #139551641