### PR TITLE
#139551647 Failed jobs dashboard tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ hc/local_settings.py
 static-collected
 .DS_Store
 static/.DS_Store
+.idea/

--- a/hc/front/tests/test_my_failed_jobs.py
+++ b/hc/front/tests/test_my_failed_jobs.py
@@ -9,6 +9,60 @@ class MyChecksTestCase(BaseTestCase):
     def setUp(self):
         super(MyChecksTestCase, self).setUp()
         self.check = Check(user=self.alice, name="Alice Was Here")
-        self.check.last_ping = timezone.now() - td(days=3)
         self.check.status = "up"
         self.check.save()
+
+    def test_it_works(self):
+        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.status = self.check.get_status()
+        self.check.save()
+        print("\n*** alice check: ", self.check.__dict__)
+
+        for email in ("alice@example.org", "bob@example.org"):
+            self.client.login(username=email,
+                              password="password")
+            r = self.client.get("/failed-jobs/")
+
+            self.assertContains(r, "Alice Was Here", status_code=200)
+
+    def test_it_doesnt_have_working_checks(self):
+        self.check.last_ping = timezone.now()
+        self.check.status = self.check.get_status()
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.get("/failed-jobs/")
+
+        # Desktop
+        self.assertNotContains(r, "icon-up")
+
+        # Mobile
+        self.assertNotContains(r, "label-success")
+
+    def test_it_has_failed_jobs(self):
+        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.status = self.check.get_status()
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.get("/failed-jobs/")
+
+        # Desktop
+        self.assertContains(r, "icon-down")
+
+        # Mobile
+        self.assertContains(r, "label-danger")
+
+    def test_it_doesnt_show_grace_check(self):
+        self.check.last_ping = timezone.now() - td(days=1, minutes=30)
+        self.check.status = self.check.get_status()
+        self.check.save()
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.get("/failed-jobs/")
+
+        # Desktop
+        self.assertNotContains(r, "icon-grace")
+
+        # Mobile
+        self.assertNotContains(r, "label-warning")

--- a/hc/front/tests/test_my_failed_jobs.py
+++ b/hc/front/tests/test_my_failed_jobs.py
@@ -16,7 +16,6 @@ class MyChecksTestCase(BaseTestCase):
         self.check.last_ping = timezone.now() - td(days=3)
         self.check.status = self.check.get_status()
         self.check.save()
-        print("\n*** alice check: ", self.check.__dict__)
 
         for email in ("alice@example.org", "bob@example.org"):
             self.client.login(username=email,

--- a/hc/front/tests/test_my_failed_jobs.py
+++ b/hc/front/tests/test_my_failed_jobs.py
@@ -1,0 +1,14 @@
+from hc.api.models import Check
+from hc.test import BaseTestCase
+from datetime import timedelta as td
+from django.utils import timezone
+
+
+class MyChecksTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(MyChecksTestCase, self).setUp()
+        self.check = Check(user=self.alice, name="Alice Was Here")
+        self.check.last_ping = timezone.now() - td(days=3)
+        self.check.status = "up"
+        self.check.save()

--- a/hc/front/urls.py
+++ b/hc/front/urls.py
@@ -31,6 +31,7 @@ channel_urls = [
 urlpatterns = [
     url(r'^$', views.index, name="hc-index"),
     url(r'^checks/$', views.my_checks, name="hc-checks"),
+    url(r'^failed-jobs/$', views.failed_jobs, name="hc-failed-jobs"),
     url(r'^checks/add/$', views.add_check, name="hc-add-check"),
     url(r'^checks/([\w-]+)/', include(check_urls)),
     url(r'^integrations/', include(channel_urls)),

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -64,9 +64,8 @@ def my_checks(request):
 
 
 def failed_jobs(request):
-    q = Check.objects.filter(user=request.team.user).filter(
-        status="down").order_by("created")
-    checks = list(q)
+    q = Check.objects.filter(user=request.team.user).order_by("created")
+    checks = [check for check in list(q) if check.get_status() == "down"]
 
     counter = Counter()
     down_tags, grace_tags, nag_tags = set(), set(), set()

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -67,7 +67,6 @@ def failed_jobs(request):
     q = Check.objects.filter(user=request.team.user).filter(
         status="down").order_by("created")
     checks = list(q)
-    print("************",checks, "***********")
 
     counter = Counter()
     down_tags, grace_tags, nag_tags = set(), set(), set()

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,6 +77,10 @@
                         <a href="{% url 'hc-checks' %}">Checks</a>
                     </li>
 
+                    <li {% if page == 'failed-jobs' %} class="active" {% endif %}>
+                        <a href="{% url 'hc-failed-jobs' %}">Failed Jobs</a>
+                    </li>
+
                     <li {% if page == 'channels' %} class="active" {% endif %}>
                         <a href="{% url 'hc-channels' %}">Integrations</a>
                     </li>

--- a/templates/front/failed_jobs.html
+++ b/templates/front/failed_jobs.html
@@ -42,14 +42,6 @@
     {% endif %}
     </div>
 </div>
-<div class="row">
-    <div class="col-sm-12">
-        <form method="post" action="{% url 'hc-add-check' %}" class="text-center">
-            {% csrf_token %}
-            <input type="submit" class="btn btn-primary btn-lg" value="Add Check">
-        </form>
-    </div>
-</div>
 
 <div id="update-name-modal" class="modal">
     <div class="modal-dialog">

--- a/templates/front/failed_jobs.html
+++ b/templates/front/failed_jobs.html
@@ -1,0 +1,312 @@
+{% extends "base.html" %}
+{% load compress staticfiles %}
+
+{% block title %}Failed Jobs - healthchecks.io{% endblock %}
+
+
+{% block content %}
+<div class="row">
+    <div class="col-sm-12">
+        <h1>
+        {% if request.team == request.user.profile %}
+            Failed Jobs
+        {% else %}
+            {{ request.team.team_name }}
+        {% endif %}
+        </h1>
+    </div>
+    {% if tags %}
+    <div id="my-checks-tags" class="col-sm-12">
+        {% for tag, count in tags %}
+            {% if tag in down_tags %}
+                <button class="btn btn-danger btn-xs" data-toggle="button">{{ tag }}</button>
+            {% elif tag in grace_tags %}
+                <button class="btn btn-warning btn-xs" data-toggle="button">{{ tag }}</button>
+            {% else %}
+                <button class="btn btn-default btn-xs" data-toggle="button">{{ tag }}</button>
+            {% endif %}
+        {% endfor %}
+    </div>
+    {% endif %}
+
+</div>
+<div class="row">
+    <div class="col-sm-12">
+
+
+    {% if checks %}
+        {% include "front/my_checks_mobile.html" %}
+        {% include "front/my_checks_desktop.html" %}
+    {% else %}
+    <div class="alert alert-info">You don't have any checks yet.</div>
+    {% endif %}
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-12">
+        <form method="post" action="{% url 'hc-add-check' %}" class="text-center">
+            {% csrf_token %}
+            <input type="submit" class="btn btn-primary btn-lg" value="Add Check">
+        </form>
+    </div>
+</div>
+
+<div id="update-name-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-name-form" class="form-horizontal" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="update-timeout-title">Name and Tags</h4>
+                </div>
+                <div class="modal-body">
+                        <div class="form-group">
+                            <label for="update-name-input" class="col-sm-2 control-label">
+                                Name
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-name-input"
+                                    name="name"
+                                    type="text"
+                                    value="---"
+                                    placeholder="unnamed"
+                                    class="input-name form-control" />
+
+                                <span class="help-block">
+                                    Give this check a human-friendly name,
+                                    so you can easily recognize it later.
+                                </span>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="update-tags-input" class="col-sm-2 control-label">
+                                Tags
+                            </label>
+                            <div class="col-sm-9">
+                                <input
+                                    id="update-tags-input"
+                                    name="tags"
+                                    type="text"
+                                    value=""
+                                    placeholder="production www"
+                                    class="form-control" />
+
+                                <span class="help-block">
+                                    Optionally, assign tags for easy filtering.
+                                    Separate multiple tags with spaces.
+                                </span>
+                            </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="update-timeout-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="update-timeout-form" method="post">
+            {% csrf_token %}
+            <input type="hidden" name="timeout" id="update-timeout-timeout" />
+              <input type="hidden" name="grace" id="update-timeout-grace" />
+            <input type="hidden" name="nag_interval" id="update-timeout-nag_interval" />
+            <div class="modal-content">
+                <div class="modal-body">
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="Expected time between pings.">
+                            Period
+                        </span>
+                        <span
+                            id="period-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+                    <div id="period-slider"></div>
+
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="When check is late, how much time to wait until alert is sent">
+                            Grace Time
+                        </span>
+                        <span
+                            id="grace-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+
+                    <div id="grace-slider"></div>
+
+                    <div class="update-timeout-info text-center">
+                        <span
+                            class="update-timeout-label"
+                            data-toggle="tooltip"
+                            title="Intervals between which emails are sent when job is down.">
+                            Nag Interval
+                        </span>
+                        <span
+                            id="nag-slider-value"
+                            class="update-timeout-value">
+                            1 day
+                        </span>
+                    </div>
+
+                    <div id="nag-slider"></div>
+
+                    <div class="update-timeout-terms">
+                        <p>
+                            <span>Period</span>
+                            Expected time between pings.
+                        </p>
+                        <p>
+                            <span>Grace Time</span>
+                            When a check is late, how much time to wait until alert is sent.
+                        </p>
+                        <p>
+                            <span>Nag Interval</span>
+                            Intervals between which emails are sent when job is down.
+                        </p>
+                    </div>
+
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="remove-check-modal" class="modal">
+    <div class="modal-dialog">
+        <form id="remove-check-form" method="post">
+            {% csrf_token %}
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="remove-check-title">Remove Check <span class="remove-check-name"></span></h4>
+                </div>
+                <div class="modal-body">
+                    <p>You are about to remove check
+                        <strong class="remove-check-name">---</strong>.
+                    </p>
+                    <p>Once it's gone there is no "undo" and you cannot get
+                    the old ping URL back.</p>
+                    <p>Are you sure?</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Remove</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div id="show-usage-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <ul class="nav nav-pills" role="tablist">
+                    <li class="active">
+                        <a href="#crontab" data-toggle="tab">Crontab</a>
+                    </li>
+                    <li>
+                        <a href="#bash" data-toggle="tab">Bash</a>
+                    </li>
+                    <li>
+                        <a href="#python" data-toggle="tab">Python</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#node" data-toggle="tab">Node.js</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#php" data-toggle="tab">PHP</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#browser" data-toggle="tab">Browser</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#powershell" data-toggle="tab">PowerShell</a>
+                    </li>
+                    <li class="hidden-xs">
+                        <a href="#email" data-toggle="tab">Email</a>
+                    </li>
+                </ul>
+
+            </div>
+            <div class="modal-body">
+
+
+                <div class="tab-content">
+                    {% with ping_url="<span class='ex'></span>" %}
+                    <div role="tabpanel" class="tab-pane active" id="crontab">
+                        {% include "front/snippets/crontab.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="bash">
+                        {% include "front/snippets/bash.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="python">
+                        {% include "front/snippets/python.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="node">
+                        {% include "front/snippets/node.html" %}
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="php">
+                        {% include "front/snippets/php.html" %}
+                    </div>
+                    <div class="tab-pane" id="browser">
+                        {% include "front/snippets/browser.html" %}
+                    </div>
+                    <div class="tab-pane" id="powershell">
+                        {% include "front/snippets/powershell.html" %}
+                    </div>
+                    <div class="tab-pane" id="email">
+                            As an alternative to HTTP/HTTPS requests,
+                            you can "ping" this check by sending an
+                            email message to
+                            <div class="email-address">
+                                <code class="em"></code>
+                            </div>
+                    </div>
+                    {% endwith %}
+                </div>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Got It!</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<form id="pause-form" method="post">
+    {% csrf_token %}
+</form>
+
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/nouislider.min.js' %}"></script>
+<script src="{% static 'js/clipboard.min.js' %}"></script>
+<script src="{% static 'js/checks.js' %}"></script>
+{% endcompress %}
+{% endblock %}

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -23,9 +23,11 @@
             {% elif check.in_grace_period %}
                 <span class="status icon-grace"></span>
             {% elif check.get_status == "up" %}
-                <span class="status icon-up"></span>
+                <span class="status icon-up"
+                    data-toggle="tooltip" title="Check status- UP"></span>
             {% elif check.get_status == "down" %}
-                <span class="status icon-down"></span>
+                <span class="status icon-down"
+                    data-toggle="tooltip" title="Check status- DOWN"></span>
             {% endif %}
         </td>
         <td class="name-cell">


### PR DESCRIPTION
#### What does this PR do?
Adds a failed jobs tab on the user dashboard.

#### Description of Task completed
_Previously_
When a User's job goes down, the user was sent a notification email informing him of the same

_Added feature_
Apart from the email notifications, the user now has a separate dashboard view of their failed jobs

#### How should this be manually tested?
At the root of the project folder, execute the following command:
`./manage.py test hc.front.tests.test_my_failed_jobs`

#### The following files were added:
```
hc/templates/front/failed_jobs.html
hc/front/tests/test_my_failed_jobs.py
```

#### The following files were modified:
`hc/front/views.py`

#### What are the relevant pivotal tracker stories?
#139551647

#### Screenshot
![Failed jobs view](https://i.imgur.com/bwxxYBUr.png)
